### PR TITLE
バックキーを押下した際に端末のホーム画面に戻されるバグ修正

### DIFF
--- a/android/java/src/org/cocos2dx/lib/webview/Cocos2dxWebView.java
+++ b/android/java/src/org/cocos2dx/lib/webview/Cocos2dxWebView.java
@@ -5,6 +5,8 @@ import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
 import android.util.Log;
+import android.view.MotionEvent;
+import android.view.KeyEvent;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
 import android.widget.FrameLayout;
@@ -98,5 +100,13 @@ public class Cocos2dxWebView extends WebView {
         layoutParams.width = width;
         layoutParams.height = height;
         this.setLayoutParams(layoutParams);
+    }
+
+    @Override
+    public boolean onKeyDown(int keyCode, KeyEvent event) {
+        if (keyCode == KeyEvent.KEYCODE_BACK && !canGoBack()) {
+            return true;
+        }
+        return super.onKeyDown(keyCode, event);
     }
 }


### PR DESCRIPTION
<h3>原因・症状</h3>
WebViewをタッチしてバックキーを押下すると端末のホーム画面に戻されてしまい、その後再起動すると表示が壊れてしまう状況に陥ってしまう。
原因としては戻り先のページが存在しないため、Activityが終了してしまいアプリごとそのまま落ちてしまうといった感じでした。
android限定のバグです。


<h3>対処</h3>
バックキーを押した際に、戻り先が無い場合は何もしないように修正しました。