### PR TITLE
WebViewのバックキーでベージを戻す

### DIFF
--- a/android/java/src/org/cocos2dx/lib/webview/Cocos2dxWebView.java
+++ b/android/java/src/org/cocos2dx/lib/webview/Cocos2dxWebView.java
@@ -104,7 +104,10 @@ public class Cocos2dxWebView extends WebView {
 
     @Override
     public boolean onKeyDown(int keyCode, KeyEvent event) {
-        if (keyCode == KeyEvent.KEYCODE_BACK && !canGoBack()) {
+        if (keyCode == KeyEvent.KEYCODE_BACK) {
+            if (canGoBack()) {
+                goBack();
+            }
             return true;
         }
         return super.onKeyDown(keyCode, event);


### PR DESCRIPTION
WebViewのバックキーのデフォルト動作がアプリの終了のため、バックキーを押されるとアプリが閉じてしまう不具合への対応。以前のPRで戻る画面がない場合は対処されていたのですが、ページが送られた時の対応が抜けていました。