### PR TITLE
[ISHIN-7054]Unify operation of evaluateJS on Android and iOS.

### DIFF
--- a/android/java/src/org/cocos2dx/lib/webview/Cocos2dxWebViewHelper.java
+++ b/android/java/src/org/cocos2dx/lib/webview/Cocos2dxWebViewHelper.java
@@ -2,6 +2,7 @@ package org.cocos2dx.lib.webview;
 
 import android.os.Handler;
 import android.os.Looper;
+import android.os.Build;
 import android.util.SparseArray;
 import android.view.View;
 import android.widget.FrameLayout;
@@ -336,7 +337,9 @@ public class Cocos2dxWebViewHelper {
             public void run() {
                 Cocos2dxWebView webView = webViews.get(index);
                 if (webView != null) {
-                    webView.evaluateJavascript(js, null);
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
+                        webView.evaluateJavascript(js, null);
+                    }
                 }
             }
         });

--- a/android/java/src/org/cocos2dx/lib/webview/Cocos2dxWebViewHelper.java
+++ b/android/java/src/org/cocos2dx/lib/webview/Cocos2dxWebViewHelper.java
@@ -336,7 +336,7 @@ public class Cocos2dxWebViewHelper {
             public void run() {
                 Cocos2dxWebView webView = webViews.get(index);
                 if (webView != null) {
-                    webView.loadUrl("javascript:" + js);
+                    webView.evaluateJavascript(js, null);
                 }
             }
         });


### PR DESCRIPTION
AndroidとiOSでevaluateJSの挙動が違っていたので、統一するようにしました。
