### PR TITLE
[ISHINKI-1659] Bot対策：androidのWebView修正

### DIFF
--- a/android/java/src/org/cocos2dx/lib/webview/Cocos2dxWebView.java
+++ b/android/java/src/org/cocos2dx/lib/webview/Cocos2dxWebView.java
@@ -9,8 +9,10 @@ import android.view.MotionEvent;
 import android.view.KeyEvent;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
+import android.webkit.WebSettings;
 import android.widget.FrameLayout;
 import android.graphics.Color;
+import android.os.Build;
 
 import java.lang.reflect.Method;
 import java.net.URI;
@@ -39,6 +41,11 @@ public class Cocos2dxWebView extends WebView {
         this.getSettings().setJavaScriptEnabled(true);
 
 		this.setBackgroundColor(Color.TRANSPARENT);
+
+        // httpから始まるURLを許可する
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            this.getSettings().setMixedContentMode(WebSettings.MIXED_CONTENT_ALWAYS_ALLOW);
+        }
 
         // `searchBoxJavaBridge_` has big security risk. http://jvn.jp/en/jp/JVN53768697
         try {


### PR DESCRIPTION
## 概要
- Bot対策のWebView対応

## 変更内容
- android5.0以降でhttps以外のURLがWebviewで表示できなくなっているので、Capy認証用にその制限を解除する

## 関連リンク
### チケット
https://jira.aktsk.jp/browse/ISHINKI-1659

### 仕様書
https://wiki.aktsk.jp/pages/viewpage.action?pageId=173130187

## 他の機能への影響
- WebViewを使っている箇所

## 動作確認方法
- ishin_client側のPRに記載（ https://github.com/aktsk/ishin-client/pull/5948 ）

## 補足
- 検証の時はandroid5.0より前のものとそれ以降のもので動作するかは最低限確認してほしいです。