### PR TITLE
[ISHINKI-2494] WebView上のURLから別ブラウザを起動して表示させるよう修正

### DIFF
--- a/android/java/src/org/cocos2dx/lib/webview/Cocos2dxWebView.java
+++ b/android/java/src/org/cocos2dx/lib/webview/Cocos2dxWebView.java
@@ -74,9 +74,10 @@ public class Cocos2dxWebView extends WebView {
                 Cocos2dxWebViewHelper.getCocos2dxActivity().startActivity(intent);
                 return true;
             }
-            // WebView上のURLリンクをタップした時ブラウザを起動させる
-            Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(urlString));
-            Cocos2dxWebViewHelper.getCocos2dxActivity().startActivity(intent);
+            // WebView上のURLリンクをタップした時、起動するブラウザを選択させる（複数ブラウザがインストールされてる場合のみ）
+            Intent target = new Intent(Intent.ACTION_VIEW, Uri.parse(urlString));
+            Intent chooser = Intent.createChooser(target, null); // 引数をnullにするとタイトルが「アプリで開く」となる。
+            Cocos2dxWebViewHelper.getCocos2dxActivity().startActivity(chooser);
             return true;
         }
 

--- a/android/java/src/org/cocos2dx/lib/webview/Cocos2dxWebView.java
+++ b/android/java/src/org/cocos2dx/lib/webview/Cocos2dxWebView.java
@@ -76,7 +76,7 @@ public class Cocos2dxWebView extends WebView {
             }
             // WebView上のURLリンクをタップした時、起動するブラウザを選択させる（複数ブラウザがインストールされてる場合のみ）
             Intent target = new Intent(Intent.ACTION_VIEW, Uri.parse(urlString));
-            Intent chooser = Intent.createChooser(target, null); // 引数をnullにするとタイトルが「アプリで開く」となる。
+            Intent chooser = Intent.createChooser(target, null);
             Cocos2dxWebViewHelper.getCocos2dxActivity().startActivity(chooser);
             return true;
         }

--- a/android/java/src/org/cocos2dx/lib/webview/Cocos2dxWebView.java
+++ b/android/java/src/org/cocos2dx/lib/webview/Cocos2dxWebView.java
@@ -69,17 +69,15 @@ public class Cocos2dxWebView extends WebView {
     class Cocos2dxWebViewClient extends WebViewClient {
         @Override
         public boolean shouldOverrideUrlLoading(WebView view, String urlString) {
-            URI uri = URI.create(urlString);
-            if (uri != null && uri.getScheme().equals(jsScheme)) {
-                Cocos2dxWebViewHelper._onJsCallback(viewTag, urlString);
-                return true;
-            }
             if (urlString.startsWith("mailto:")) {
-            	Intent intent = new Intent(Intent.ACTION_SENDTO, Uri.parse(urlString));
-            	Cocos2dxWebViewHelper.getCocos2dxActivity().startActivity(intent);
+                Intent intent = new Intent(Intent.ACTION_SENDTO, Uri.parse(urlString));
+                Cocos2dxWebViewHelper.getCocos2dxActivity().startActivity(intent);
                 return true;
             }
-            return Cocos2dxWebViewHelper._shouldStartLoading(viewTag, urlString);
+            // WebView上のURLリンクをタップした時ブラウザを起動させる
+            Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(urlString));
+            Cocos2dxWebViewHelper.getCocos2dxActivity().startActivity(intent);
+            return true;
         }
 
         @Override

--- a/ios/UIWebViewWrapper.mm
+++ b/ios/UIWebViewWrapper.mm
@@ -156,8 +156,9 @@
 #pragma mark - UIWebViewDelegate
 - (BOOL)webView:(UIWebView *)webView shouldStartLoadWithRequest:(NSURLRequest *)request navigationType:(UIWebViewNavigationType)navigationType {
     NSString *url = [[request URL] absoluteString];
-    if ([[[request URL] scheme] isEqualToString:self.jsScheme]) {
-        self.onJsCallback([url UTF8String]);
+    if (navigationType == UIWebViewNavigationTypeLinkClicked) {
+        // WebView上のURLリンクをタップした時ブラウザを起動させる
+        [[UIApplication sharedApplication] openURL:request.URL];
         return NO;
     }
     if (self.shouldStartLoading) {


### PR DESCRIPTION
## 概要
WebView上のURLから別ブラウザを起動して表示させるよう修正しました。

## 変更内容
サブモジュール（cocos2dx-WebView）

**ishin-client側のPRはこちらです。**
https://github.com/aktsk/ishin-client/pull/6261

## :warning: デザインPRリンク
- ishin_design PR URL

## 関連リンク
### チケット
https://jira.aktsk.jp/browse/ISHINKI-2494

### 仕様書
https://wiki.aktsk.jp/pages/viewpage.action?pageId=168284409

## 他の機能への影響
-

## 動作確認方法
- iOS、Androidの両方にてご確認下さい。
- ガシャ画面の左上「特定商取引に基づく表示」ボタン → WebView内の「こちら」リンク → ブラウザが起動して表示される。

## :white_check_mark: 実装者チェックリスト
- [ ] 担当プランナーに動作を見てもらったか？
- [ ] リソースリストを作成したか？
  - リソースリストとは？:[リソース管理ページの記述方法](https://akatsuki.atlassian.net/wiki/pages/viewpage.action?pageId=73697228)
- [ ] Xcodeで各ビルドターゲットごとにFrameworkを設定したか(SDK導入時etc.)

## :white_check_mark: レビュアーチェックリスト
- [ ] このPRに関連するデザインPRをマージしたか？

## 保留項目とTODOリスト
- なし
