### PR TITLE
[ISHINKI-3687] webviewのキャッシュが残っていて、HTMLファイルを更新しても正しく反映されない事がある。

### DIFF
--- a/android/java/src/org/cocos2dx/lib/webview/Cocos2dxWebViewHelper.java
+++ b/android/java/src/org/cocos2dx/lib/webview/Cocos2dxWebViewHelper.java
@@ -78,6 +78,7 @@ public class Cocos2dxWebViewHelper {
                 newView.setVerticalScrollBarEnabled(oldView.isVerticalScrollBarEnabled());
                 newView.setHorizontalScrollBarEnabled(oldView.isHorizontalScrollBarEnabled());
                 newView.setWebViewRect(oldView.getLeft(), oldView.getTop(), oldView.getWidth(), oldView.getHeight());
+                newView.clearCache(true);
                 newView.loadUrl(oldView.getUrl());
 
                 webViews.put(key, newView);
@@ -228,6 +229,7 @@ public class Cocos2dxWebViewHelper {
             public void run() {
                 Cocos2dxWebView webView = webViews.get(index);
                 if (webView != null) {
+                    webView.clearCache(true);
                     webView.loadUrl(url);
                 }
             }
@@ -241,6 +243,7 @@ public class Cocos2dxWebViewHelper {
             public void run() {
                 Cocos2dxWebView webView = webViews.get(index);
                 if (webView != null) {
+                    webView.clearCache(true);
                     webView.loadUrl(filePath);
                 }
             }
@@ -258,6 +261,7 @@ public class Cocos2dxWebViewHelper {
                         for (String[] header: headers) {
                             extraHeader.put(header[0], header[1]);
                         }
+                        webView.clearCache(true);
                         webView.loadUrl(url, extraHeader);
                     }
                 }

--- a/ios/UIWebViewWrapper.h
+++ b/ios/UIWebViewWrapper.h
@@ -8,8 +8,6 @@
 #include <string>
 #include <map>
 
-extern const NSTimeInterval DEFAULT_INTERVAL;
-
 @interface UIWebViewWrapper : NSObject
 @property (nonatomic) std::function<bool(std::string url)> shouldStartLoading;
 @property (nonatomic) std::function<void(std::string url)> didFinishLoading;

--- a/ios/UIWebViewWrapper.h
+++ b/ios/UIWebViewWrapper.h
@@ -8,6 +8,7 @@
 #include <string>
 #include <map>
 
+extern const NSTimeInterval DEFAULT_INTERVAL;
 
 @interface UIWebViewWrapper : NSObject
 @property (nonatomic) std::function<bool(std::string url)> shouldStartLoading;

--- a/ios/UIWebViewWrapper.mm
+++ b/ios/UIWebViewWrapper.mm
@@ -9,6 +9,7 @@
 #import "CCEAGLView.h"
 #import "CCDirector.h"
 
+extern const NSTimeInterval DEFAULT_INTERVAL = 60.0;
 
 @interface UIWebViewWrapper () <UIWebViewDelegate>
 @property(nonatomic, retain) UIWebView *uiWebView;
@@ -99,14 +100,18 @@
 - (void)loadUrl:(const std::string &)urlString {
     if (!self.uiWebView) {[self setupWebView];}
     NSURL *url = [NSURL URLWithString:@(urlString.c_str())];
-    NSURLRequest *request = [NSURLRequest requestWithURL:url];
+    NSURLRequest *request = [NSURLRequest requestWithURL:url
+                             cachePolicy:NSURLRequestReloadIgnoringLocalCacheData
+                             timeoutInterval:DEFAULT_INTERVAL];
     [self.uiWebView loadRequest:request];
 }
 
 - (void)loadFile:(const std::string &)filePath {
     if (!self.uiWebView) {[self setupWebView];}
     NSURL *url = [NSURL fileURLWithPath:@(filePath.c_str())];
-    NSURLRequest *request = [NSURLRequest requestWithURL:url];
+    NSURLRequest *request = [NSURLRequest requestWithURL:url
+                             cachePolicy:NSURLRequestReloadIgnoringLocalCacheData
+                             timeoutInterval:DEFAULT_INTERVAL];
     [self.uiWebView loadRequest:request];
 }
 

--- a/ios/UIWebViewWrapper.mm
+++ b/ios/UIWebViewWrapper.mm
@@ -9,7 +9,7 @@
 #import "CCEAGLView.h"
 #import "CCDirector.h"
 
-extern const NSTimeInterval DEFAULT_INTERVAL = 60.0;
+const NSTimeInterval DEFAULT_INTERVAL = 60.0;
 
 @interface UIWebViewWrapper () <UIWebViewDelegate>
 @property(nonatomic, retain) UIWebView *uiWebView;


### PR DESCRIPTION
## 概要
これまでwebViewのキャッシュがクライアントで残って居いて、各種HTMLファイル（利用規約や特商法取引部分）の更新時に
cloudfrontのキャッシュを削除して再更新が走る状態になったのにも関わらず、クライアントの各種OS側のキャッシュが効いており直ぐに更新されない事がありました。

更新タイミングは端末による様子で、直ぐに反映されるものもあれば、長時間反映されないものがあったので、
iOS / android 両方共、URLファイルを開く前に明示的にwebviewのキャッシュを削除する様に修正しました。

この修正によって、常にサーバに新しいファイルをリクエストし、それを読み込む様になります。

## 変更内容
iOS / android 両方共、URLファイルを開く前に明示的にwebviewのキャッシュを削除する様にしました。

## :warning: デザインPRリンク
- ishin_design PR URL

## 関連リンク
### チケット
https://jira.aktsk.jp/browse/ISHINKI-3687

### 仕様書


## 他の機能への影響
webview 仕様箇所全て。
capy認証部分(!)、利用規約、特商法取引部分、資金決済法部分、twitter連動部分

## 動作確認方法
・各種ページを開いてみて、今までと同じ挙動をとっている事を確認する（特にcapy部分は良く見てください）
・例）特商法のページの文字を一文字変更して、S3にアップ -> 終わったらhubotで ```hubot cache invalidate /html/ja/* dev``` を実行してサーバのキャッシュを消して、
　その後に特商法のページを見て即座に文言が変わっている事を確認する。

## :white_check_mark: 実装者チェックリスト
- [ ] 自動テストを書いたか
- [ ] 担当プランナーに動作を見てもらったか？
- [ ] 担当デザイナーに動作を見てもらったか？
- [ ] リソースリストを作成したか？
  - リソースリストとは？:[リソース管理ページの記述方法](https://akatsuki.atlassian.net/wiki/pages/viewpage.action?pageId=73697228)
- [ ] Xcodeで各ビルドターゲットごとにFrameworkを設定したか(SDK導入時etc.)

## :white_check_mark: レビュアーチェックリスト
- [ ] このPRに関連するデザインPRをマージしたか？

## 保留項目とTODOリスト
- なし
